### PR TITLE
Allow configuring overlay styles in an animated fashion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ class Application extends React.Component {
 - `onStartShouldSetResponderCapture` (Function) - Function that accepts event as an argument and specify if side-menu should react on the touch or not. Check https://facebook.github.io/react-native/docs/gesture-responder-system.html for more details
 - `onChange` (Function) - Callback on menu open/close. Is passed `isOpen` as an argument
 - `menuPosition` (String) - either 'left' or 'right', defaults to 'left'
-- `animationFunction` (Function -> Object) - Function that accept 2 arguments (prop, value) and return an object:
+- `animationFunction` (Function -> Object) - Function that accepts 2 arguments (prop, value) and return an object:
   - `prop` you should use at the place you specify parameter to animate
   - `value` you should use to specify the final value of `prop`
-- `animationStyle` (Function -> Object) - Function that accept 1 argument (value) and return an object:
+- `animationStyle` (Function -> Object) - Function that accepts the arguments `(value: Animated.Value, maxValue: number)` and return an object:
   - `value` you should use at the place you need current value of animated parameter (left offset of content view)
+- `overlayAnimationStyle` (Function -> Object) - Function that accepts the arguments `(value: Animated.Value, maxValue: number)` and returns style properties for the content view overlay: useful for doing fade animations as the menu opens
 - `bounceBackOnOverdraw` - when true, content view will bounce back to `openMenuOffset` when dragged further, defaults to true
 
 ### FAQ

--- a/index.js
+++ b/index.js
@@ -177,22 +177,24 @@ class SideMenu extends React.Component {
    * @return {React.Component}
    */
   getContentView() {
-    let overlay = null;
-
-    if (this.isOpen) {
-      overlay = (
-        <TouchableWithoutFeedback onPress={() => this.openMenu(false)}>
-          <View style={styles.overlay} />
-        </TouchableWithoutFeedback>
-      );
-    }
+    const overlay = (
+      <TouchableWithoutFeedback onPress={() => this.openMenu(false)}>
+        <Animated.View
+          style={[
+            styles.overlay,
+            this.props.overlayAnimationStyle(this.state.left, this.props.openMenuOffset)
+          ]}
+          pointerEvents={this.isOpen ? 'auto' : 'none'}
+        />
+      </TouchableWithoutFeedback>
+    );
 
     const { width, height, } = this.state;
     const ref = (sideMenu) => this.sideMenu = sideMenu;
     const style = [
       styles.frontView,
       { width, height, },
-      this.props.animationStyle(this.state.left),
+      this.props.animationStyle(this.state.left, this.props.openMenuOffset),
     ];
 
     return (
@@ -235,6 +237,8 @@ SideMenu.propTypes = {
   toleranceY: React.PropTypes.number,
   menuPosition: React.PropTypes.oneOf(['left', 'right', ]),
   onChange: React.PropTypes.func,
+  animationStyle: React.PropTypes.func,
+  overlayAnimationStyle: React.PropTypes.func,
   openMenuOffset: React.PropTypes.number,
   hiddenMenuOffset: React.PropTypes.number,
   disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool, ]),
@@ -252,13 +256,14 @@ SideMenu.defaultProps = {
   hiddenMenuOffset: 0,
   onStartShouldSetResponderCapture: () => true,
   onChange: () => {},
-  animationStyle: (value) => {
+  animationStyle: (value, maxValue) => {
     return {
       transform: [{
         translateX: value,
       }, ],
     };
   },
+  overlayAnimationStyle: (value, maxValue) => ({}),
   animationFunction: (prop, value) => {
     return Animated.spring(
       prop,


### PR DESCRIPTION
This PR supersedes #192 as it is strictly more expressive.

This PR allows the consumer to pass a function to style the overlay, just like the
one that styles the main wrapper view. The use-case for this is to allow e.g. fades
as you drag the menu over (it's a very nice effect!).

Because you can't style the component if it isn't mounted (i.e., during the initial
slide-out of the side menu), the overlay is now always rendered. It only captures
touch events if the menu is considered "open" so that the view behind the overlay
continues to work as normal while the menu is closed.

I also added animationStyle to propTypes and included an extra parameter to match the
new overlayAnimationStyle (the latter of which needs to know the maximum extent of
the pan gesture to animate a fade properly).