### PR TITLE
Update ReactNative @0.26+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 //@noflow
 const styles = require('./styles');
 const ReactNative = require('react-native');
-const React = require('react');
 const { Dimensions, Animated, } = ReactNative;
 const deviceScreen = Dimensions.get('window');
 
@@ -9,8 +8,10 @@ const {
   PanResponder,
   View,
   TouchableWithoutFeedback,
+  InteractionManager
 } = ReactNative;
 
+import React, {Component} from 'react'
 /**
  * Size of the amount you can move content view in the opened menu state and
  * release without menu closing
@@ -28,7 +29,7 @@ function shouldOpenMenu(dx: Number) {
   return dx > barrierForward;
 }
 
-class SideMenu extends React.Component {
+class SideMenu extends Component {
   constructor(props) {
     super(props);
 
@@ -150,6 +151,7 @@ class SideMenu extends React.Component {
   }
 
   moveLeft(offset) {
+
     const newOffset = this.menuPositionMultiplier() * offset;
 
     this.props
@@ -165,10 +167,11 @@ class SideMenu extends React.Component {
    */
   openMenu(isOpen) {
     const { hiddenMenuOffset, openMenuOffset, } = this.props;
+    var handle = InteractionManager.createInteractionHandle();
     this.moveLeft(isOpen ? openMenuOffset : hiddenMenuOffset);
     this.isOpen = isOpen;
-
     this.forceUpdate();
+    InteractionManager.clearInteractionHandle(handle);
     this.props.onChange(isOpen);
   }
 
@@ -269,7 +272,7 @@ SideMenu.defaultProps = {
     );
   },
   isOpen: false,
-  bounceBackOnOverdraw: true,
+  bounceBackOnOverdraw: false,
 };
 
 module.exports = SideMenu;


### PR DESCRIPTION
In React Native v0.26+ separate React and ReactNative. 
So as default React is not part of ReactNative package anymore.

and also this PR fix some issue in performance, need to add InteractionManager when doing some expensive animation like open or close the menu. 
