### PR TITLE
Add optional onMove method for handling animations while menu is swiping

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ class Application extends React.Component {
 - `disableGestures` (Bool) - Disable whether the menu can be opened with gestures or not
 - `onStartShouldSetResponderCapture` (Function) - Function that accepts event as an argument and specify if side-menu should react on the touch or not. Check https://facebook.github.io/react-native/docs/gesture-responder-system.html for more details
 - `onChange` (Function) - Callback on menu open/close. Is passed `isOpen` as an argument
+- `onMove` (Function) - Callback on menu move. Is passed `left` as an argument
 - `menuPosition` (String) - either 'left' or 'right', defaults to 'left'
 - `animationFunction` (Function -> Object) - Function that accept 2 arguments (prop, value) and return an object:
   - `prop` you should use at the place you specify parameter to animate

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ class SideMenu extends React.Component {
       if (!this.props.bounceBackOnOverdraw && Math.abs(newLeft) > this.props.openMenuOffset) {
         newLeft = this.menuPositionMultiplier() * this.props.openMenuOffset;
       }
-
+      this.props.onMove(newLeft);
       this.state.left.setValue(newLeft);
     }
   }
@@ -151,7 +151,6 @@ class SideMenu extends React.Component {
 
   moveLeft(offset) {
     const newOffset = this.menuPositionMultiplier() * offset;
-
     this.props
       .animationFunction(this.state.left, newOffset)
       .start();
@@ -181,7 +180,7 @@ class SideMenu extends React.Component {
 
     if (this.isOpen) {
       overlay = (
-        <TouchableWithoutFeedback onPress={() => this.openMenu(false)}>
+        <TouchableWithoutFeedback onPress={() => this.openMenu(false) }>
           <View style={styles.overlay} />
         </TouchableWithoutFeedback>
       );
@@ -215,15 +214,15 @@ class SideMenu extends React.Component {
   render() {
 
     const boundryStyle = this.props.menuPosition == 'right' ?
-      {left: deviceScreen.width - this.props.openMenuOffset} :
-      {right: deviceScreen.width - this.props.openMenuOffset} ;
+      { left: deviceScreen.width - this.props.openMenuOffset } :
+      { right: deviceScreen.width - this.props.openMenuOffset };
 
     const menu = <View style={[styles.menu, boundryStyle]}>{this.props.menu}</View>;
 
     return (
-      <View style={styles.container} onLayout={this.onLayoutChange.bind(this)}>
+      <View style={styles.container} onLayout={this.onLayoutChange.bind(this) }>
         {menu}
-        {this.getContentView()}
+        {this.getContentView() }
       </View>
     );
   }
@@ -233,11 +232,12 @@ SideMenu.propTypes = {
   edgeHitWidth: React.PropTypes.number,
   toleranceX: React.PropTypes.number,
   toleranceY: React.PropTypes.number,
-  menuPosition: React.PropTypes.oneOf(['left', 'right', ]),
+  menuPosition: React.PropTypes.oneOf(['left', 'right',]),
   onChange: React.PropTypes.func,
+  onMove: React.PropTypes.func,
   openMenuOffset: React.PropTypes.number,
   hiddenMenuOffset: React.PropTypes.number,
-  disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool, ]),
+  disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool,]),
   animationFunction: React.PropTypes.func,
   onStartShouldSetResponderCapture: React.PropTypes.func,
   isOpen: React.PropTypes.bool,
@@ -250,13 +250,14 @@ SideMenu.defaultProps = {
   edgeHitWidth: 60,
   openMenuOffset: deviceScreen.width * 2 / 3,
   hiddenMenuOffset: 0,
+  onMove: () => { },
   onStartShouldSetResponderCapture: () => true,
-  onChange: () => {},
+  onChange: () => { },
   animationStyle: (value) => {
     return {
       transform: [{
         translateX: value,
-      }, ],
+      },],
     };
   },
   animationFunction: (prop, value) => {

--- a/index.js
+++ b/index.js
@@ -152,6 +152,7 @@ class SideMenu extends React.Component {
 
   moveLeft(offset) {
     const newOffset = this.menuPositionMultiplier() * offset;
+
     this.props
       .animationFunction(this.state.left, newOffset)
       .start();
@@ -216,7 +217,7 @@ class SideMenu extends React.Component {
 
     const boundryStyle = this.props.menuPosition == 'right' ?
       {left: deviceScreen.width - this.props.openMenuOffset} :
-      {right: deviceScreen.width - this.props.openMenuOffset};
+      {right: deviceScreen.width - this.props.openMenuOffset} ;
 
     const menu = <View style={[styles.menu, boundryStyle]}>{this.props.menu}</View>;
 
@@ -258,7 +259,7 @@ SideMenu.defaultProps = {
     return {
       transform: [{
         translateX: value,
-      },],
+      }, ],
     };
   },
   animationFunction: (prop, value) => {

--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ class SideMenu extends React.Component {
       if (!this.props.bounceBackOnOverdraw && Math.abs(newLeft) > this.props.openMenuOffset) {
         newLeft = this.menuPositionMultiplier() * this.props.openMenuOffset;
       }
+
       this.props.onMove(newLeft);
       this.state.left.setValue(newLeft);
     }
@@ -180,7 +181,7 @@ class SideMenu extends React.Component {
 
     if (this.isOpen) {
       overlay = (
-        <TouchableWithoutFeedback onPress={() => this.openMenu(false) }>
+        <TouchableWithoutFeedback onPress={() => this.openMenu(false)}>
           <View style={styles.overlay} />
         </TouchableWithoutFeedback>
       );
@@ -214,15 +215,15 @@ class SideMenu extends React.Component {
   render() {
 
     const boundryStyle = this.props.menuPosition == 'right' ?
-      { left: deviceScreen.width - this.props.openMenuOffset } :
-      { right: deviceScreen.width - this.props.openMenuOffset };
+      {left: deviceScreen.width - this.props.openMenuOffset} :
+      {right: deviceScreen.width - this.props.openMenuOffset};
 
     const menu = <View style={[styles.menu, boundryStyle]}>{this.props.menu}</View>;
 
     return (
-      <View style={styles.container} onLayout={this.onLayoutChange.bind(this) }>
+      <View style={styles.container} onLayout={this.onLayoutChange.bind(this)}>
         {menu}
-        {this.getContentView() }
+        {this.getContentView()}
       </View>
     );
   }
@@ -232,12 +233,12 @@ SideMenu.propTypes = {
   edgeHitWidth: React.PropTypes.number,
   toleranceX: React.PropTypes.number,
   toleranceY: React.PropTypes.number,
-  menuPosition: React.PropTypes.oneOf(['left', 'right',]),
+  menuPosition: React.PropTypes.oneOf(['left', 'right', ]),
   onChange: React.PropTypes.func,
   onMove: React.PropTypes.func,
   openMenuOffset: React.PropTypes.number,
   hiddenMenuOffset: React.PropTypes.number,
-  disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool,]),
+  disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool, ]),
   animationFunction: React.PropTypes.func,
   onStartShouldSetResponderCapture: React.PropTypes.func,
   isOpen: React.PropTypes.bool,
@@ -250,9 +251,9 @@ SideMenu.defaultProps = {
   edgeHitWidth: 60,
   openMenuOffset: deviceScreen.width * 2 / 3,
   hiddenMenuOffset: 0,
-  onMove: () => { },
+  onMove: () => {},
   onStartShouldSetResponderCapture: () => true,
-  onChange: () => { },
+  onChange: () => {},
   animationStyle: (value) => {
     return {
       transform: [{


### PR DESCRIPTION
It seems like some people (myself included) want to run some kind of animation of an overlay while the menu is swiping open or closed. (see #235 #192).

Personally, I like how small and simple this side menu component is but I do need to support this more advanced functionality. I would like to style the overlay, but the overlay in this component is really just used for touch events, so would rather not complicate it. The least intrusive and most performant method I've been able to put together is just a function `onMove` that runs as the menu is swiped open or closed. Users of the component can then render their own overlay view based on data from that function.

Happy to provide code example but I just set the state of a component in both `onMove` and `onChange`. The component interpolates that value using RN `Animation` and sets it as the opacity of an overlay view.