### PR TITLE
Add autoClosing in component props

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ class Application extends React.Component {
 | animationFunction | none | (Function -> Object) | Function that accept 2 arguments (prop, value) and return an object: <br /> - `prop` you should use at the place you specify parameter to animate <br /> - `value` you should use to specify the final value of prop |
 | animationStyle | none | (Function -> Object) | Function that accept 1 argument (value) and return an object: <br /> - `value` you should use at the place you need current value of animated parameter (left offset of content view) |
 | bounceBackOnOverdraw | true | boolean | when true, content view will bounce back to openMenuOffset when dragged further |
+| autoClosing | true | boolean | When true, menu close automatically as soon as an event occurs |
 
 ### FAQ
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ class SideMenu extends React.Component {
   }
 
   componentWillReceiveProps(props) {
-    if (typeof props.isOpen !== 'undefined' && this.isOpen !== props.isOpen) {
+    if (typeof props.isOpen !== 'undefined' && this.isOpen !== props.isOpen && (props.autoClosing || this.isOpen === false)) {
       this.openMenu(props.isOpen);
     }
   }
@@ -252,6 +252,7 @@ SideMenu.propTypes = {
   onStartShouldSetResponderCapture: React.PropTypes.func,
   isOpen: React.PropTypes.bool,
   bounceBackOnOverdraw: React.PropTypes.bool,
+  autoClosing: React.PropTypes.bool
 };
 
 SideMenu.defaultProps = {
@@ -279,7 +280,9 @@ SideMenu.defaultProps = {
       }
     );
   },
+  isOpen: false,
   bounceBackOnOverdraw: true,
+  autoClosing: true,
 };
 
 module.exports = SideMenu;


### PR DESCRIPTION
## Context

In some case, it's necessary to use `SideMenu` as a view and not a menu.
If you insert a `<TextInput>` in the component and you tap something, the sidemenu close immediately

## Change

I simply add a new component props which prevent that if you add `autoClosing={false}`.

## Example

```
   <SideMenu
        menu={menu}
        isOpen={this.state.isOpen}
        onChange={(isOpen) => this.updateMenuState(isOpen)}
        autoClosing={false}
      >
        <View style={styles.container}>
          <Text style={styles.welcome}>
            Welcome to React Native!
          </Text>
          <Text style={styles.instructions}>
            To get started, edit index.ios.js
          </Text>
          <Text style={styles.instructions}>
            Press Cmd+R to reload,{'\n'}
            Cmd+Control+Z for dev menu
          </Text>
          <Text style={styles.instructions}>
            Current selected menu item is: {this.state.selectedItem}
          </Text>
        </View>
        <Button style={styles.button} onPress={() => this.toggle()}>
          <Image
            source={require('./assets/menu.png')} style={{width: 32, height: 32}} />
        </Button>
    </SideMenu>
```

## Edit

There is a problem with pull request #221. Why prop `isOpen` is missing ? Because now, it's always undefined...