### PR TITLE
Rerender child components when the parent changes this.props.isOpen

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ class SideMenu extends React.Component {
   }
 
   componentWillReceiveProps(props) {
-    if (typeof props.isOpen !== 'undefined' && this.isOpen !== props.isOpen && (props.autoClosing || this.isOpen === false)) {
+    if (typeof props.isOpen !== 'undefined' && this.props.isOpen !== props.isOpen && (props.autoClosing || this.isOpen === false)) {
       this.openMenu(props.isOpen);
     }
   }


### PR DESCRIPTION
Instead of checking for `this.isOpen !== props.isOpen`, we need to check for `this.props.isOpen !== props.isOpen`, so that the parent component can ~~close the menu~~ force child components to re-render by updating the `isOpen` prop. 

(`this.isOpen` and `this.props.isOpen` can get out of sync.)