### PR TITLE
Added pan responder terminate to dismiss bugs on android when we swipe e and a tab or scroll responder enters to action

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ class SideMenu extends React.Component {
       onMoveShouldSetPanResponder: this.handleMoveShouldSetPanResponder.bind(this),
       onPanResponderMove: this.handlePanResponderMove.bind(this),
       onPanResponderRelease: this.handlePanResponderEnd.bind(this),
+      onPanResponderTerminate: this.handlePanResponderEnd.bind(this),      
     });
   }
 


### PR DESCRIPTION
Hello all

Developing the one feature in my project I realize that in the cases that you are on an android device and have a tab-view or scrollable view, the menu gets stuck on the point that the scroll entered to action, just in the cases that the scroll is reaching the bottom. This is caused by the thing that we are not listening the onPanResponderTerminate event.

Ass the docs of PanResponder say:
````
// onPanResponderTerminate:
// Another component has become the responder, so this gesture
// should be cancelled
````

I would like to include this bugfix on this awesome library @Kureev 