### PR TITLE
Fixed an error that is causing the view of elements that are outside our main view like, carousels, tabs, navigation elements or whatever you put outside the device width

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -26,6 +26,7 @@ module.exports = StyleSheet.create({
     left: 0,
     top: 0,
     backgroundColor: 'transparent',
+    overflow: 'hidden'
   },
   overlay: {
     ...absoluteStretch,


### PR DESCRIPTION
Hello everyone

Working with react-native-side-menu I realized about the fact that when you have outside of screen elements the 'frontView'  or Animated.View and the library applies an openMenu the whole view get moved but if the off screen elements like next carousel images, tabs, navigationCards(on navigation experimental) will overlap our menu. 

This behavior is only caused on IOS because Android have overflow set to true by default always on views.

To avoid that, and reproduce the same behavior as in android, I putted the overflow hidden on the frontView styles too. 

Hope that this PR will be useful and help someone with their problems.

Waiting for your response @Kureev 