### PR TITLE
Add Animation Callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ class Application extends React.Component {
 | onSliding | none | Function | Callback when menu is sliding. It returns a decimal from 0 to 1 which represents the percentage of menu offset between hiddenMenuOffset and openMenuOffset.|
 | menuPosition | left | String | either 'left' or 'right' |
 | animationFunction | none | (Function -> Object) | Function that accept 2 arguments (prop, value) and return an object: <br /> - `prop` you should use at the place you specify parameter to animate <br /> - `value` you should use to specify the final value of prop |
-| onAnimationComplete | none | (Function -> Void) | Function that accept 1 optional argument (event): <br /> - `event` you should use at the place you specify parameter to capture the animation event once finished  |
+| onAnimationComplete | none | (Function -> Void) | Function that accept 1 optional argument (event): <br /> - `event` you should this to capture the animation event after the animation has successfully completed |
 | animationStyle | none | (Function -> Object) | Function that accept 1 argument (value) and return an object: <br /> - `value` you should use at the place you need current value of animated parameter (left offset of content view) |
 | bounceBackOnOverdraw | true | boolean | when true, content view will bounce back to openMenuOffset when dragged further |
 | autoClosing | true | boolean | When true, menu close automatically as soon as an event occurs |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ class Application extends React.Component {
 | onSliding | none | Function | Callback when menu is sliding. It returns a decimal from 0 to 1 which represents the percentage of menu offset between hiddenMenuOffset and openMenuOffset.|
 | menuPosition | left | String | either 'left' or 'right' |
 | animationFunction | none | (Function -> Object) | Function that accept 2 arguments (prop, value) and return an object: <br /> - `prop` you should use at the place you specify parameter to animate <br /> - `value` you should use to specify the final value of prop |
+| onAnimationComplete | none | (Function -> Void) | Function that accept 1 optional argument (event): <br /> - `event` you should use at the place you specify parameter to capture the animation event once finished  |
 | animationStyle | none | (Function -> Object) | Function that accept 1 argument (value) and return an object: <br /> - `value` you should use at the place you need current value of animated parameter (left offset of content view) |
 | bounceBackOnOverdraw | true | boolean | when true, content view will bounce back to openMenuOffset when dragged further |
 | autoClosing | true | boolean | When true, menu close automatically as soon as an event occurs |

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ type Props = {
   hiddenMenuOffset: number,
   disableGestures: Function | bool,
   animationFunction: Function,
+  onAnimationComplete: Function,
   onStartShouldSetResponderCapture: Function,
   isOpen: bool,
   bounceBackOnOverdraw: bool,
@@ -162,7 +163,7 @@ export default class SideMenu extends React.Component {
 
     this.props
       .animationFunction(this.state.left, newOffset)
-      .start();
+      .start(this.props.onAnimationComplete);
 
     this.prevLeft = newOffset;
   }
@@ -269,6 +270,7 @@ SideMenu.propTypes = {
   animationStyle: PropTypes.func,
   disableGestures: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   animationFunction: PropTypes.func,
+  onAnimationComplete: PropTypes.func,
   onStartShouldSetResponderCapture: PropTypes.func,
   isOpen: PropTypes.bool,
   bounceBackOnOverdraw: PropTypes.bool,
@@ -298,6 +300,7 @@ SideMenu.defaultProps = {
     toValue: value,
     friction: 8,
   }),
+  onAnimationComplete: () => {},
   isOpen: false,
   bounceBackOnOverdraw: true,
   autoClosing: true,


### PR DESCRIPTION
This is a pull request to add an optional callback function to the Animated `.start()` function. 

Simple Usage:
```javascript
onAnimationComplete = event => { 
  // Do something with the event object
}

<SideMenu
    onAnimationComplete={this.onAnimationComplete}
/>
```