### PR TITLE
When the menu position is set to `left` but React Native is running i…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "eslint-plugin-react": "^7.1.0",
     "flow-bin": "0.49",
     "react": "16.0.0-alpha.12",
-    "react-native": "^0.46.3"
+    "react-native": "^0.51.0"
   }
 }


### PR DESCRIPTION
…n RTL mode, the menu does not correctly render. It should render at the start of the viewport, which would be on the right in RTL mode. Instead it continues to render on the left.

`left` and `right` positions are misleading in this library. The intention of `left` and `right` (as per how its coded) is to behave more like `start` and `end` in React Native.

- This commit adds some new menuPosition props options for `start` and `end` which are intended to deprecate `left` and `right`.
- It also adds a new function to allow calculating whether we should consider the menuPosition as at the 'start' of the viewport which will be left in LTR mode and right in RTL mode.
- It also adds a function which uses this new calculation to decide what side the menu should be rendered on.
- it also calculates the animation direction based on a combination of RTL mode and the menuPosition setting.