### PR TITLE
Allow external toggle function

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,13 @@ export default class SideMenu extends React.Component {
 
     if (this.isOpen) {
       overlay = (
-        <TouchableWithoutFeedback onPress={() => this.openMenu(false)}>
+        <TouchableWithoutFeedback onPress={() => {
+          if (this.props.externalToggle) {
+            this.props.externalToggle();
+          }
+          this.openMenu(false);
+        }}
+        >
           <View style={styles.overlay} />
         </TouchableWithoutFeedback>
       );
@@ -275,6 +281,7 @@ SideMenu.propTypes = {
   isOpen: PropTypes.bool,
   bounceBackOnOverdraw: PropTypes.bool,
   autoClosing: PropTypes.bool,
+  externalToggle: PropTypes.func,
 };
 
 SideMenu.defaultProps = {
@@ -304,4 +311,5 @@ SideMenu.defaultProps = {
   isOpen: false,
   bounceBackOnOverdraw: true,
   autoClosing: true,
+  externalToggle: () => {},
 };


### PR DESCRIPTION
I'm not sure if anyone else experiences this issue, but when the SideMenu is opened and closed via an external trigger, you have to tap the external button again in order for the toggle to work.

I thought this issue was related to https://github.com/facebook/react-native/issues/12784, but everything I tried still resulted in the "toggle" button needing to be pressed twice after close. After debugging, I narrowed it down to this package. When I remove this package, buttons work just fine.

The behavior seems to only happen after the SideMenu is open. The menu closes, but any onPress function does not fire after, until it's pressed again. The internal state of the component updates the `isOpen` prop on local state.

This proposed change allows an externalToggle (function) be passed in, which fires when the "overlay" component is pressed.

Feedback is greatly appreciated as I don't know if this is a good workaround and/or update to the package. Additionally I'm not well versed with TypeScript.