### PR TITLE
Updated methods componentWillMount / componentWillReceiveProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ export default class SideMenu extends React.Component {
     this.state.left.addListener(({value}) => this.props.onSliding(Math.abs((value - this.state.hiddenMenuOffset) / (this.state.openMenuOffset - this.state.hiddenMenuOffset))));
   }
 
-  componentWillMount(): void {
+  UNSAFE_componentWillMount(): void {
     this.responder = PanResponder.create({
       onStartShouldSetResponderCapture: this.onStartShouldSetResponderCapture,
       onMoveShouldSetPanResponder: this.onMoveShouldSetPanResponder,
@@ -114,7 +114,7 @@ export default class SideMenu extends React.Component {
     });
   }
 
-  componentWillReceiveProps(props: Props): void {
+  UNSAFE_componentWillReceiveProps(props: Props): void {
     if (typeof props.isOpen !== 'undefined' && this.isOpen !== props.isOpen && (props.autoClosing || this.isOpen === false)) {
       this.openMenu(props.isOpen);
     }


### PR DESCRIPTION
The methods componentWillMount and componentWillReceiveProps are now called with their new aliases: UNSAFE_componentWillMount and UNSAFE_componentWillReceiveProps, in this way the deprecation warning doesn't appears and the library will work in react 17.0 too. For more info about the change see: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path

## Test Plan
Commands:
- react-native run
- run on OS X (simulator and device)
Outputs:
- The same as before without deprecation warning in debug mode

### What's required for testing (prerequisites)?
- There aren't prerequisites

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
